### PR TITLE
Use conda root prefix

### DIFF
--- a/src/rhumba.cpp
+++ b/src/rhumba.cpp
@@ -84,12 +84,14 @@ void hide_banner()
 // [[Rcpp::export]]
 void print_config()
 {
+    mamba_use_conda_root_prefix();
     mamba_config_list();
 }
 
 // [[Rcpp::export]]
 void list(const char* regex = "", const char* prefix = "")
 {
+    mamba_use_conda_root_prefix();
     set_prefix(prefix);
     mamba_list(regex);
 }
@@ -97,6 +99,7 @@ void list(const char* regex = "", const char* prefix = "")
 // [[Rcpp::export]]
 void create(const std::vector<std::string>& specs, const char* prefix)
 {
+    mamba_use_conda_root_prefix();
     hide_banner();
     set_specs(specs);
     set_prefix(prefix);
@@ -106,6 +109,7 @@ void create(const std::vector<std::string>& specs, const char* prefix)
 // [[Rcpp::export]]
 void install(const std::vector<std::string>& specs, const char* prefix = "")
 {
+    mamba_use_conda_root_prefix();
     hide_banner();
     set_specs(specs);
     set_prefix(prefix);
@@ -115,6 +119,7 @@ void install(const std::vector<std::string>& specs, const char* prefix = "")
 // [[Rcpp::export]]
 void update(const std::vector<std::string>& specs, int update_all = 0, const char* prefix = "")
 {
+    mamba_use_conda_root_prefix();
     hide_banner();
     set_specs(specs);
     set_prefix(prefix);
@@ -124,6 +129,7 @@ void update(const std::vector<std::string>& specs, int update_all = 0, const cha
 // [[Rcpp::export]]
 void remove(const std::vector<std::string>& specs, int remove_all = 0, const char* prefix = "")
 {
+    mamba_use_conda_root_prefix();
     hide_banner();
     set_specs(specs);
     set_prefix(prefix);
@@ -133,6 +139,7 @@ void remove(const std::vector<std::string>& specs, int remove_all = 0, const cha
 // [[Rcpp::export]]
 void info(const char* prefix = "")
 {
+    mamba_use_conda_root_prefix();
     set_prefix(prefix);
     mamba_info();
 }


### PR DESCRIPTION
Description
---

Use default conda root prefix if `MAMBA_ROOT_PREFIX` is not defined.
It fixes installation root prefix when installing with conda or mamba.